### PR TITLE
Move docs to /usr/share/doc

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -58,9 +58,9 @@ h1,h2,h3,h4,h5,h6,.ll{font-family:'Share';font-weight:bold;padding:0;line-height
   <a class="button" href="https://cms.XXX/">CMS WEBSITE</a>
 </div>
 <div class="container">
-<div class="ll"><a href="file:///opt/cppref/reference/en/index.html">C/C++ Reference</a></div>
-<div class="ll"><a href="file:///usr/share/doc/stl-manual/html/index.html">STL Manual</a></div>
-<div class="ll"><a href="file:///opt/ioi/html/vm.html">Contestant VM Manual</a></div>
+<div class="ll"><a href="../cppreference/reference/en/index.html">C/C++ Reference</a></div>
+<div class="ll"><a href="../stl-manual/html/index.html">STL Manual</a></div>
+<div class="ll"><a href="vm.html">Contestant VM Manual</a></div>
 </div>
 </body>
 </html>

--- a/misc/mozilla/firefox/dqb69w9m.default-release/prefs.js
+++ b/misc/mozilla/firefox/dqb69w9m.default-release/prefs.js
@@ -44,7 +44,7 @@ user_pref("browser.safebrowsing.provider.mozilla.nextupdatetime", "1594042348580
 user_pref("browser.shell.mostRecentDateSetAsDefault", "1594038747");
 user_pref("browser.slowStartup.averageTime", 3870);
 user_pref("browser.slowStartup.samples", 1);
-user_pref("browser.startup.homepage", "file:///opt/ioi/html/index.html");
+user_pref("browser.startup.homepage", "file:///usr/share/doc/ioi/index.html");
 user_pref("browser.startup.homepage_override.buildID", "20210527174632");
 user_pref("browser.startup.homepage_override.mstone", "89.0");
 user_pref("browser.startup.lastColdStartupCheck", 1622703426);

--- a/misc/mozilla/firefox/dqb69w9m.default-release/user.js
+++ b/misc/mozilla/firefox/dqb69w9m.default-release/user.js
@@ -1,3 +1,3 @@
-user_pref("browser.startup.homepage", "file:///opt/ioi/html/index.html");
+user_pref("browser.startup.homepage", "file:///usr/share/doc/ioi/index.html");
 user_pref("browser.safebrowsing.malware.enabled", false);
 user_pref("browser.safebrowsing.phishing.enabled", false);

--- a/setup.sh
+++ b/setup.sh
@@ -186,8 +186,8 @@ apt -y install stl-manual python3-doc
 # CPP Reference
 
 wget -O /tmp/html_book_20190607.zip http://upload.cppreference.com/mwiki/images/b/b2/html_book_20190607.zip
-mkdir -p /opt/cppref
-unzip -o /tmp/html_book_20190607.zip -d /opt/cppref
+mkdir -p /usr/share/doc/cppreference
+unzip -o /tmp/html_book_20190607.zip -d /usr/share/doc/cppreference
 rm -f /tmp/html_book_20190607.zip
 
 # Build logkeys
@@ -232,12 +232,12 @@ depmod -a
 
 # Create local HTML
 
-cp -a html /opt/ioi/html
-mkdir -p /opt/ioi/html/fonts
+cp -a html /usr/share/doc/ioi
+mkdir -p /usr/share/doc/ioi/fonts
 wget -O /tmp/fira-sans.zip "https://gwfh.mranftl.com/api/fonts/fira-sans?download=zip&subsets=latin&variants=regular"
 wget -O /tmp/share.zip "https://gwfh.mranftl.com/api/fonts/share?download=zip&subsets=latin&variants=regular"
-unzip -o /tmp/fira-sans.zip -d /opt/ioi/html/fonts
-unzip -o /tmp/share.zip -d /opt/ioi/html/fonts
+unzip -o /tmp/fira-sans.zip -d /usr/share/doc/ioi/fonts
+unzip -o /tmp/share.zip -d /usr/share/doc/ioi/fonts
 rm /tmp/fira-sans.zip
 rm /tmp/share.zip
 


### PR DESCRIPTION
As firefox is installed through snap, it only has access to its own config file and /usr/share/doc through the system-packages-doc interface. This commit should allow firefox to access cpppreference and the ioi home page.