### PR TITLE
Set limits according to the rules for IOI 2023

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -152,7 +152,7 @@ chmod 644 /var/lib/AccountsService/users/ansible
 
 # GRUB config: quiet, and password for edit
 
-sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/ s/"$/ quiet splash maxcpus=2 mem=6144M"/' /etc/default/grub
+sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/ s/"$/ quiet splash maxcpus=8 mem=8192M"/' /etc/default/grub
 GRUB_PASSWD=$(echo -e "$ANSIBLE_PASSWD\n$ANSIBLE_PASSWD" | grub-mkpasswd-pbkdf2 | awk '/hash of / {print $NF}')
 
 sed -i '/\$(echo "\$os" | grub_quote)'\'' \${CLASS}/ s/'\'' \$/'\'' --unrestricted \$/' /etc/grub.d/10_linux


### PR DESCRIPTION
In the rules for IOI 2023 (https://ioi2023.hu/contest-environment/), there is a maximum amount of 8 GB of RAM and 8 cores of cpu.