### PR TITLE
Only remove cache in cleanup.sh

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,6 +3,7 @@
 set -e
 
 apt clean
+rm -rf /var/lib/snapd/cache/*
 
 rm -rf /var/lib/apt/lists/*
 

--- a/setup.sh
+++ b/setup.sh
@@ -345,8 +345,6 @@ snap list --all | awk '/disabled/{print $1, $3}' | while read snapname revision;
 	snap remove "$snapname" --revision="$revision"
 done
 
-rm -rf /var/lib/snapd/cache/*
-
 # Mark g++ as explicitly needed
 
 apt -y install g++
@@ -354,8 +352,6 @@ apt -y install g++
 # Clean up apt
 
 apt -y autoremove
-
-apt clean
 
 # Remove desktop backgrounds
 rm -rf /usr/share/backgrounds/*.jpg


### PR DESCRIPTION
I want to store the package cache on my host machine so I don't have to download half the universe every time I try to build this. This way I could just mount a share before running setup and unmount it before running cleanup.

(I also want to store the other temporary files that are currently saved in /tmp but that's a bigger change)