### PR TITLE
Do not install openssh-server in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ netplan apply
 
 # Install tools needed for management and monitoring
 
-apt -y install net-tools openssh-server ansible xvfb tinc oathtool imagemagick \
+apt -y install net-tools ansible xvfb tinc oathtool imagemagick \
 	zabbix-agent
 
 # Install local build tools


### PR DESCRIPTION
The automatic installation already takes care of installing `openssh-server`, so don't do it in `setup.sh` as it is redundant.