### PR TITLE
autoinstall: kill HTTP server when exiting

### DIFF
--- a/autoinstall/start-autoinstall.sh
+++ b/autoinstall/start-autoinstall.sh
@@ -9,6 +9,8 @@ wget -c -O ubuntu.iso https://www.releases.ubuntu.com/22.04/ubuntu-22.04.2-live-
 
 # Open http server for port 8000
 python3 -m http.server &
+HTTP_SRV_PID=$!
+trap 'kill $HTTP_SRV_PID' EXIT
 
 # Make contestant-vm available
 tar czvf contestant-vm.tar.gz --exclude autoinstall --exclude .git --exclude .github -C ../.. contestant-vm


### PR DESCRIPTION
Otherwise the HTTP server will keep running unnecessarily and prevent running `start-autoinstall.sh` again because port tcp/8000 will be used.